### PR TITLE
feat(mlflow): implementar servidor MLflow con configuracion desde .en…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,142 @@
+# =====================================================
+# docker-compose.yml — PoC Asistente Fitosanitario con IA
+# UAO 2026 — Desarrollo de Proyectos de IA
+# =====================================================
+# Levanta los 5 servicios del sistema con un solo comando:
+#   docker compose up --build
+#
+# Servicios:
+#   mlflow    — Tracking de experimentos (puerto 5000)
+#   cv        — Servicio Vision Computacional gRPC (puerto 50051)
+#   nlp       — Servicio NLP gRPC (puerto 50052)
+#   app       — Interfaz Streamlit (puerto 8501)
+#
+# Prerequisitos:
+#   - Tener .env configurado con OPENAI_API_KEY
+#   - Docker Desktop corriendo
+# =====================================================
+
+services:
+
+  # ---------------------------------------------------
+  # MLflow — Tracking de experimentos y Model Registry
+  # Debe arrancar primero: cv depende de el
+  # ---------------------------------------------------
+  mlflow:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: poc_mlflow
+    command: ["uv", "run", "python", "mlflow_server.py"]
+    ports:
+      - "${MLFLOW_PORT:-5000}:5000"
+    environment:
+      - MLFLOW_HOST=0.0.0.0
+      - MLFLOW_PORT=${MLFLOW_PORT:-5000}
+      - MLFLOW_BACKEND_URI=${MLFLOW_BACKEND_URI:-./mlruns}
+      - MLFLOW_ARTIFACT_ROOT=${MLFLOW_ARTIFACT_ROOT:-./mlartifacts}
+    volumes:
+      # Persiste experimentos y artefactos fuera del contenedor
+      - mlflow_data:/app/mlruns
+      - mlflow_artifacts:/app/mlartifacts
+    networks:
+      - poc_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # ---------------------------------------------------
+  # Servicio CV — Vision Computacional gRPC
+  # Descarga MobileNetV2 desde HuggingFace en el primer arranque
+  # ---------------------------------------------------
+  cv:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: poc_cv
+    command: ["uv", "run", "python", "src/api/cv_server.py"]
+    ports:
+      - "${CV_SERVICE_PORT:-50051}:50051"
+    environment:
+      - CV_SERVICE_PORT=${CV_SERVICE_PORT:-50051}
+      - MLFLOW_TRACKING_URI=http://mlflow:${MLFLOW_PORT:-5000}
+      - HUGGINGFACE_TOKEN=${HUGGINGFACE_TOKEN:-}
+    volumes:
+      # Cachea el modelo para no descargarlo en cada arranque
+      - hf_cache:/app/hf_cache
+    networks:
+      - poc_network
+    depends_on:
+      mlflow:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ---------------------------------------------------
+  # Servicio NLP — OpenAI GPT-5 Nano gRPC
+  # Requiere OPENAI_API_KEY en .env
+  # ---------------------------------------------------
+  nlp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: poc_nlp
+    command: ["uv", "run", "python", "src/api/nlp_server.py"]
+    ports:
+      - "${NLP_SERVICE_PORT:-50052}:50052"
+    environment:
+      - NLP_SERVICE_PORT=${NLP_SERVICE_PORT:-50052}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    networks:
+      - poc_network
+    restart: unless-stopped
+
+  # ---------------------------------------------------
+  # App — Interfaz Streamlit
+  # Orquesta las llamadas a cv y nlp via gRPC
+  # ---------------------------------------------------
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: poc_app
+    command: ["uv", "run", "streamlit", "run", "src/app/app.py",
+              "--server.port=8501", "--server.address=0.0.0.0"]
+    ports:
+      - "${APP_PORT:-8501}:8501"
+    environment:
+      - APP_PORT=${APP_PORT:-8501}
+      - CV_SERVICE_HOST=cv
+      - CV_SERVICE_PORT=${CV_SERVICE_PORT:-50051}
+      - NLP_SERVICE_HOST=nlp
+      - NLP_SERVICE_PORT=${NLP_SERVICE_PORT:-50052}
+      - MLFLOW_TRACKING_URI=http://mlflow:${MLFLOW_PORT:-5000}
+    networks:
+      - poc_network
+    depends_on:
+      - cv
+      - nlp
+    restart: unless-stopped
+
+# =====================================================
+# Volumes — persisten datos entre reinicios
+# =====================================================
+volumes:
+  mlflow_data:
+    name: poc_mlflow_data
+  mlflow_artifacts:
+    name: poc_mlflow_artifacts
+  hf_cache:
+    name: poc_hf_cache
+
+# =====================================================
+# Network — red interna entre servicios
+# Los servicios se comunican por nombre (cv, nlp, mlflow)
+# =====================================================
+networks:
+  poc_network:
+    name: poc_network
+    driver: bridge

--- a/mlflow_server.py
+++ b/mlflow_server.py
@@ -1,0 +1,108 @@
+"""
+mlflow_server.py — Servidor MLflow para tracking de experimentos
+PoC Asistente Fitosanitario con IA | UAO 2026
+
+Responsabilidad unica: arrancar el servidor MLflow con configuracion
+leida desde variables de entorno (.env).
+
+Uso local:
+    uv run python mlflow_server.py
+
+Uso en Docker Compose (Modulo 4):
+    command: ["uv", "run", "python", "mlflow_server.py"]
+
+Variables de entorno requeridas (.env):
+    MLFLOW_TRACKING_URI  — URI del servidor (default: http://localhost:5000)
+    MLFLOW_HOST          — Host donde escucha (default: 0.0.0.0)
+    MLFLOW_PORT          — Puerto del servidor (default: 5000)
+    MLFLOW_BACKEND_URI   — Backend de almacenamiento (default: ./mlruns)
+    MLFLOW_ARTIFACT_ROOT — Carpeta de artefactos (default: ./mlartifacts)
+"""
+
+import os
+import subprocess
+import sys
+import logging
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Configuracion de logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [MLFLOW-SERVER] %(levelname)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def get_config() -> dict:
+    """
+    Lee la configuracion del servidor MLflow desde variables de entorno.
+
+    Returns:
+        dict: Configuracion con host, port, backend_uri y artifact_root.
+    """
+    return {
+        "host":          os.getenv("MLFLOW_HOST",          "0.0.0.0"),
+        "port":          os.getenv("MLFLOW_PORT",          "5000"),
+        "backend_uri":   os.getenv("MLFLOW_BACKEND_URI",   "./mlruns"),
+        "artifact_root": os.getenv("MLFLOW_ARTIFACT_ROOT", "./mlartifacts"),
+    }
+
+
+def serve() -> None:
+    """
+    Arranca el servidor MLflow con la configuracion del entorno.
+
+    Construye y ejecuta el comando mlflow server con los parametros
+    leidos desde .env. El proceso reemplaza al proceso Python actual
+    (os.execvp) para que Docker maneje correctamente las senales
+    de parada (SIGTERM, Ctrl+C).
+    """
+    config = get_config()
+
+    logger.info("Iniciando servidor MLflow...")
+    logger.info("Host:           %s", config["host"])
+    logger.info("Puerto:         %s", config["port"])
+    logger.info("Backend URI:    %s", config["backend_uri"])
+    logger.info("Artifact Root:  %s", config["artifact_root"])
+    logger.info(
+        "UI disponible en: http://localhost:%s", config["port"]
+    )
+
+    cmd = [
+        "mlflow", "server",
+        "--host",                config["host"],
+        "--port",                config["port"],
+        "--backend-store-uri",   config["backend_uri"],
+        "--default-artifact-root", config["artifact_root"],
+    ]
+
+    logger.info("Comando: %s", " ".join(cmd))
+
+    try:
+        # subprocess.run mantiene el proceso vivo y propaga Ctrl+C
+        result = subprocess.run(cmd, check=True)
+        sys.exit(result.returncode)
+    except FileNotFoundError:
+        logger.error(
+            "MLflow no encontrado. Asegurate de haber corrido: uv sync"
+        )
+        sys.exit(1)
+    except KeyboardInterrupt:
+        logger.info("Servidor MLflow detenido.")
+        sys.exit(0)
+    except subprocess.CalledProcessError as e:
+        logger.error("Error al iniciar MLflow: %s", e)
+        sys.exit(e.returncode)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    serve()


### PR DESCRIPTION
**Título:** `[FEAT] Servidor MLflow + Docker Compose + Makefile`
```
## Descripción
Implementación del servidor MLflow como script Python configurable desde .env.
Docker Compose con los 5 servicios del sistema (MLflow, CV, NLP, Streamlit)
listos para Módulo 3 local y Módulo 4 en DigitalOcean.
Makefile como punto de entrada centralizado para todas las tareas del proyecto.
Documentación de acceso al servidor MLflow para el equipo en docs/mlflow.md.

## Tipo de cambio
- [x] feat
- [x] chore
- [x] docs

## Issues relacionados
Closes #26
Closes #28

## Cómo probar
# Servidor MLflow local
make mlflow
# Verificar UI en http://localhost:5000

# Sistema completo con Docker
make docker-up
# Verificar todos los servicios corriendo

# Estructura del proyecto
make arbol

## Checklist
- [x] PEP8
- [x] Docstrings en todas las funciones
- [x] Sin credenciales en el código
- [x] .env no incluido
- [x] mlruns/ y mlartifacts/ en .gitignore
- [x] Volúmenes Docker nombrados para persistencia en Módulo 4